### PR TITLE
Add packet types fota.py

### DIFF
--- a/software/fota/fota.py
+++ b/software/fota/fota.py
@@ -1,3 +1,4 @@
+import chardet
 import hashlib
 import socket
 import struct
@@ -7,12 +8,34 @@ PACKET_START = 0x00000001
 PACKET_FAMILY1 = 0x03E8
 PACKET_FAMILY2 = 0x07D0
 
-# packet types
-PACKET_PING = 0x0001
-PACKET_GETTIME = 0x0002
-PACKET_RDY_UPGRADE = 0x0005
-PACKET_UPLOAD_FIRMWARE = 0x0006
-PACKET_RESTART = 0x0008
+# packet_actions dictionary contains all available actions discovered so far
+packet_actions = {
+    # 1 pings the device 
+    "ping": 0x0001,
+    # 2 gets time in some strange encoding - tried chardet.detect but couldn't figure out what encoding it has
+    "time": 0x0002,
+    "restart": 0x0003,
+    "ready-upgrade": 0x0005,
+    "upload-firmware": 0x0006,
+    # 7 does something with settings - wasn't able to really discern any differences, but the camera sound for settings changed plays
+    "settings-change": 0x0007,
+    # 8 also restarts? not sure about difference with 3
+    "restart-2": 0x0008,
+    # 9 does something, return code looks like an err so maybe takes another param
+    "unknown-9": 0x0009,
+    # 10 triggers a wifi scan
+    "scan-wifi": 0x000A,
+    # 11 triggers manual recordings
+    "manual-record": 0x000B,
+    # 12 gets model, serial, firmware version details
+    "product-info": 0x000C,
+    # 13 will trigger a format of the SD card
+    "format-drive": 0x000D,
+    # 14 Gathers SIM details
+    "sim-info": 0x000C,
+    # 15 Disables SIM? or prints additional SIM info
+    "disable-sim": 0x000D
+}
 
 
 class BlackVue(object):
@@ -53,18 +76,6 @@ class BlackVue(object):
         self._send(packet)
         return self._read()
 
-    def getTime(self):
-        return self.sendPacket(PACKET_GETTIME)
-
-    def ping(self):
-        return self.sendPacket(PACKET_PING)
-
-    def restart(self):
-        return self.sendPacket(PACKET_RESTART)
-    
-    def prepareUpgrade(self):
-        return self.sendPacket(PACKET_RDY_UPGRADE)
-
     def uploadFirmware(self, firmware_path):
         firmware = None
         with open(firmware_path, "rb") as file:
@@ -76,7 +87,7 @@ class BlackVue(object):
                 ">lhhl",
                 PACKET_START,
                 PACKET_FAMILY2,
-                PACKET_UPLOAD_FIRMWARE,
+                packet_actions["upload-firmware"],
                 len(md5hash) + len(firmware),
             )
             + md5hash
@@ -99,17 +110,28 @@ x = BlackVue(host)
 x.connect()
 
 action = sys.argv[2]
-if action == "ping":
-    print(x.ping())
-elif action == "restart":
-    print(x.restart())
+
+# If packet_actions contains the action - just sendPacket with that action
+if packet_actions[action]:
+    ret = x.sendPacket(action)
+elif action == "test":
+    if len(sys.argv) != 4:
+        print("Usage python fota.py <host> test <packet to send as int>")
+        exit()
+
+    custom_packet = int(sys.argv[3])
+    ret = x.sendPacket(custom_packet)
 elif action == "upgrade":
     if len(sys.argv) != 4:
         print("Usage python fota.py <host> upgrade <path-to-tgz>")
         exit()
 
     path = sys.argv[3]
-    print(x.prepareUpgrade())
-    x.uploadFirmware(path)
+    print(x.sendPacket(packet_actions["ready-upgrade"]))
+    ret = x.uploadFirmware(path)
 
 x.close()
+print(ret)
+encoding = chardet.detect(ret)
+print(encoding)
+print(ret.decode(encoding['encoding']))

--- a/software/fota/fota.py
+++ b/software/fota/fota.py
@@ -48,27 +48,22 @@ class BlackVue(object):
 
         return self.conn.recv(length)
 
-    def getTime(self):
-        packet = struct.pack(">lhhl", PACKET_START, PACKET_FAMILY1, PACKET_GETTIME, 0)
+    def sendPacket(self, packet):
+        packet = struct.pack(">lhhl", PACKET_START, PACKET_FAMILY1, packet, 0)
         self._send(packet)
         return self._read()
+
+    def getTime(self):
+        return self.sendPacket(PACKET_GETTIME)
 
     def ping(self):
-        packet = struct.pack(">lhhl", PACKET_START, PACKET_FAMILY1, PACKET_PING, 0)
-        self._send(packet)
-        return self._read()
+        return self.sendPacket(PACKET_PING)
 
     def restart(self):
-        packet = struct.pack(">lhhl", PACKET_START, PACKET_FAMILY1, PACKET_RESTART, 0)
-        self._send(packet)
-        return self._read()
-
+        return self.sendPacket(PACKET_RESTART)
+    
     def prepareUpgrade(self):
-        packet = struct.pack(
-            ">lhhl", PACKET_START, PACKET_FAMILY1, PACKET_RDY_UPGRADE, 0
-        )
-        self._send(packet)
-        return self._read()
+        return self.sendPacket(PACKET_RDY_UPGRADE)
 
     def uploadFirmware(self, firmware_path):
         firmware = None


### PR DESCRIPTION
I've been on a quest to find a basic method of powering off the blackvue camera in some way over remote connection. Real interesting stuff in this repository - the firmware modifications don't seem to work on newer cameras (tried adding a backdoor using the cmd.cgi method to just call /sbin/poweroff on the device) but was unable to get the firmware on the DR900X to take, with both FOTA and manually overwriting the path on the SD-Card. The path in the SD-card is actually completely empty (or maybe hidden) so I think there is some precautions in place on newer firmwares. The FOTA upgrade seems to run, but after the camera reboots it's back at the same firmware prior to the FOTA running. Could also be the sue_checksum is not valid - tried several variations on the model (900X2, DR900X, 900X) with no luck.

Anyway, in FOTA I found several other packet types that can be sent to the DR900X, and updated the script here to account for them. 